### PR TITLE
update go versions used in testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.11', '1.12', '1.13', '1.14']
+        go: ['1.13', '1.14', '1.15', '1.16']
     env:
       VERBOSE: 1
       GOFLAGS: -mod=readonly


### PR DESCRIPTION
the logur test suite now depends on Duration.Milliseconds
which was introduced in go 1.13